### PR TITLE
Replace quick-error with thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ categories = ["parser-implementations"]
 homepage = "http://github.com/tailhook/resolv-conf"
 documentation = "https://docs.rs/resolv-conf/"
 repository = "http://github.com/tailhook/resolv-conf"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["paul@colomiets.name"]
 
 [dependencies]
-quick-error = "2.0.0"
+thiserror = "1"
 hostname = { version = "^0.3", optional = true }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,8 @@
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]
 
-#[macro_use]
-extern crate quick_error;
+extern crate thiserror;
+
 #[cfg(feature = "system")]
 extern crate hostname;
 


### PR DESCRIPTION
Bumps version to 0.8 as this may have slightly different trait implications.

Doesn't run cargo fmt as any fmt would massively change the project.

I did this to reduce the size of my cargo tree. I would say it increases supply chain security, except the author of this crate is the author of quick-error.

... bandwidth reduction in any Rust workload which has the thiserror crate already pulled in? That's presumably most users, especially since this crate's primary user is trust-dns (now hickory-dns) which does.

Less deps needing review? Reduced compile times?