### PR TITLE
Remove dependency on quick-error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.7.0"
 authors = ["paul@colomiets.name"]
 
 [dependencies]
-quick-error = "2.0.0"
 hostname = { version = "^0.3", optional = true }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,6 @@
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]
 
-#[macro_use]
-extern crate quick_error;
 #[cfg(feature = "system")]
 extern crate hostname;
 


### PR DESCRIPTION
Removes dependency on quick-error. I think this should be backwards compatible with the old error type.

Resolves https://github.com/tailhook/resolv-conf/issues/20