### PR TITLE
Bump hostname to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["paul@colomiets.name"]
 
 [dependencies]
 quick-error = "2.0.0"
-hostname = { version = "^0.3", optional = true }
+hostname = { version = "^0.4", optional = true }
 
 [features]
 system = ["hostname"]


### PR DESCRIPTION
Avoid unmaintained match_cfg and winapi in favor of cfg_if and windows_rs https://github.com/svartalf/hostname/pull/18