### PR TITLE
Use 1-indexed line numbers when displaying error messages

### DIFF
--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -9,36 +9,36 @@ quick_error!{
     pub enum ParseError {
         /// Error that may be returned when the string to parse contains invalid UTF-8 sequences
         InvalidUtf8(line: usize, err: Utf8Error) {
-            display("bad unicode at line {}: {}", line, err)
+            display("bad unicode at line {}: {}", line + 1, err)
             source(err)
         }
         /// Error returned a value for a given directive is invalid.
         /// This can also happen when the value is missing, if the directive requires a value.
         InvalidValue(line: usize) {
             display("directive at line {} is improperly formatted \
-                or contains invalid value", line)
+                or contains invalid value", line + 1)
         }
         /// Error returned when a value for a given option is invalid.
         /// This can also happen when the value is missing, if the option requires a value.
         InvalidOptionValue(line: usize) {
             display("directive options at line {} contains invalid \
-                value of some option", line)
+                value of some option", line + 1)
         }
         /// Error returned when a invalid option is found.
         InvalidOption(line: usize) {
-            display("option at line {} is not recognized", line)
+            display("option at line {} is not recognized", line + 1)
         }
         /// Error returned when a invalid directive is found.
         InvalidDirective(line: usize) {
-            display("directive at line {} is not recognized", line)
+            display("directive at line {} is not recognized", line + 1)
         }
         /// Error returned when a value cannot be parsed an an IP address.
         InvalidIp(line: usize, err: AddrParseError) {
-            display("directive at line {} contains invalid IP: {}", line, err)
+            display("directive at line {} contains invalid IP: {}", line + 1, err)
         }
         /// Error returned when there is extra data at the end of a line.
         ExtraData(line: usize) {
-            display("extra data at the end of the line {}", line)
+            display("extra data at the end of the line {}", line + 1)
         }
     }
 }


### PR DESCRIPTION
The line numbers stored in the ParseError struct are 0-indexed, which is reasonable as an internal representation but very confusing in displayed error messages.

### Example

with the following `resolv.conf` file:

```
nameserver 192.168.1.1
options no-aaaa
```

The current code shows the error

```
error: option at line 1 is not recognized
```

After this change, the error is

```
error: option at line 2 is not recognized
```