### PR TITLE
Add the no-aaaa option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -78,6 +78,8 @@ pub struct Config {
     pub no_check_names: bool,
     /// Try AAAA query before A
     pub inet6: bool,
+    /// Do not issue AAAA queries
+    pub no_aaaa: bool,
     /// Use reverse lookup of ipv6 using bit-label format described instead
     /// of nibble format
     pub ip6_bytestring: bool,
@@ -125,6 +127,7 @@ impl Config {
     /// assert_eq!(config.rotate, false);
     /// assert_eq!(config.no_check_names, false);
     /// assert_eq!(config.inet6, false);
+    /// assert_eq!(config.no_aaaa, false);
     /// assert_eq!(config.ip6_bytestring, false);
     /// assert_eq!(config.ip6_dotint, false);
     /// assert_eq!(config.edns0, false);
@@ -147,6 +150,7 @@ impl Config {
             rotate: false,
             no_check_names: false,
             inet6: false,
+            no_aaaa: false,
             ip6_bytestring: false,
             ip6_dotint: false,
             edns0: false,
@@ -354,6 +358,9 @@ impl fmt::Display for Config {
         }
         if self.inet6 {
             writeln!(fmt, "options inet6")?;
+        }
+        if self.no_aaaa {
+            writeln!(fmt, "options no-aaaa")?;
         }
         if self.ip6_bytestring {
             writeln!(fmt, "options ip6-bytestring")?;

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -192,6 +192,7 @@ pub(crate) fn parse(bytes: &[u8]) -> Result<Config, ParseError> {
                         ("rotate", _) => cfg.rotate = true,
                         ("no-check-names", _) => cfg.no_check_names = true,
                         ("inet6", _) => cfg.inet6 = true,
+                        ("no-aaaa", _) => cfg.no_aaaa = true,
                         ("ip6-bytestring", _) => cfg.ip6_bytestring = true,
                         ("ip6-dotint", _) => cfg.ip6_dotint = true,
                         ("no-ip6-dotint", _) => cfg.ip6_dotint = false,


### PR DESCRIPTION
This option was added in glibc 2.36. It probably doesn't make sense to support in hickory, but it's useful to parse it so that the config doesn't error entirely when someone uses it in their system config.