### PR TITLE
Replace external crate with inline code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,3 @@ homepage = "https://github.com/hickory-dns/resolv-conf"
 documentation = "https://docs.rs/resolv-conf/"
 repository = "https://github.com/hickory-dns/resolv-conf"
 version = "0.7.1"
-
-[dependencies]
-hostname = { version = "0.4", optional = true }
-
-[features]
-system = ["hostname"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -278,8 +278,7 @@ impl Config {
 
     /// Get domain from config or fallback to the suffix of a hostname
     ///
-    /// This is how glibc finds out a hostname. This method requires
-    /// ``system`` feature enabled.
+    /// This is how glibc finds out a hostname.
     pub fn get_system_domain(&self) -> Option<String> {
         if self.domain.is_some() {
             return self.domain.clone();

--- a/src/config.rs
+++ b/src/config.rs
@@ -286,7 +286,8 @@ impl Config {
         }
 
         #[link(name = "c")]
-        unsafe extern "C" {
+        /*unsafe*/
+        extern "C" {
             fn gethostname(hostname: *mut u8, size: usize) -> i32;
         }
 
@@ -467,9 +468,7 @@ fn domain_from_host(hostname: &[u8]) -> Option<String> {
     }
 
     // No dot, no domain
-    let Some(dot) = dot else {
-        return None;
-    };
+    let dot = dot?;
 
     // '.' is at the end, so the domain would be empty
     if end - dot < 2 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,9 +91,6 @@
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]
 
-#[cfg(feature = "system")]
-extern crate hostname;
-
 mod config;
 mod grammar;
 mod ip;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -351,14 +351,6 @@ fn test_get_nameservers_or_local() {
 }
 
 #[test]
-#[cfg(feature = "system")]
-#[ignore]
-fn test_get_system_domain() {
-    let config = resolv_conf::Config::new();
-    assert_eq!(Some("lan".into()), config.get_system_domain());
-}
-
-#[test]
 fn test_default_display() {
     let original_config = resolv_conf::Config::new();
     let output = original_config.to_string();


### PR DESCRIPTION
This removes the external hostname/libc dependency in favor of an inline binding. Also removes the feature flag since it only gated the optional dependency.

The only test for this was ignored since it relies on the actual configuration of the machine it is running on, so this just adds a simple unit test to ensure that the parsing of name returned by `gethostname` works as expected.

Closes: #37 (hostname is already 0.4 in the latest)