### PR TITLE
Bump version and add dummy / compat "system" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ categories = ["parser-implementations"]
 homepage = "https://github.com/hickory-dns/resolv-conf"
 documentation = "https://docs.rs/resolv-conf/"
 repository = "https://github.com/hickory-dns/resolv-conf"
+
+[features]
+# dummy feature for backwards compatibility with 0.7.1;
+# can be dropped with the next breaking version
+system = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resolv-conf"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 rust-version = "1.61"
 description = """The resolv.conf file parser"""


### PR DESCRIPTION
- **Add back dummy "system" feature for compatibility with 0.7.1**
- **Bump version to 0.7.3**

---

Based on discussion in #47 

Note that `hostname` was technically also a public feature flag because it was an optional dependency which didn't exclusively get used via `dep:hostname` syntax, but it looks like nobody should have used that one.