### PR TITLE
Fix linking regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.61.0
+          toolchain: 1.63.0
       - run: cargo check --lib --all-features
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.63.0
+          toolchain: 1.61.0
       - run: cargo check --lib --all-features
 
   lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "resolv-conf"
 version = "0.7.4"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.61"
 description = """The resolv.conf file parser"""
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -12,8 +12,10 @@ homepage = "https://github.com/hickory-dns/resolv-conf"
 documentation = "https://docs.rs/resolv-conf/"
 repository = "https://github.com/hickory-dns/resolv-conf"
 
-[dependencies]
-libc = { version = "0.2", optional = true }
-
 [features]
-system = ["dep:libc"]
+# dummy feature for backwards compatibility with 0.7.1;
+# can be dropped with the next breaking version
+system = []
+
+[dependencies]
+cfg-if = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,3 @@ repository = "https://github.com/hickory-dns/resolv-conf"
 # dummy feature for backwards compatibility with 0.7.1;
 # can be dropped with the next breaking version
 system = []
-
-[dependencies]
-cfg-if = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ repository = "https://github.com/hickory-dns/resolv-conf"
 libc = { version = "0.2", optional = true }
 
 [features]
-system = ["libc"]
+system = ["dep:libc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resolv-conf"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 rust-version = "1.61"
 description = """The resolv.conf file parser"""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "resolv-conf"
 version = "0.7.4"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 description = """The resolv.conf file parser"""
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ homepage = "https://github.com/hickory-dns/resolv-conf"
 documentation = "https://docs.rs/resolv-conf/"
 repository = "https://github.com/hickory-dns/resolv-conf"
 
+[dependencies]
+libc = { version = "0.2", optional = true }
+
 [features]
-# dummy feature for backwards compatibility with 0.7.1;
-# can be dropped with the next breaking version
-system = []
+system = ["libc"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -294,17 +294,19 @@ impl Config {
         #[cfg(all(target_os = "linux", target_feature = "crt-static"))]
         {
             use std::{fs::File, io::Read};
-            let read_bytes = match File::open("/proc/sys/kernel/hostname")
-                .and_then(|mut f| f.read(&mut hostname))
-            {
-                Ok(read_bytes) => read_bytes,
-                Err(_) => return None,
-            };
+            let mut file = File::open("/proc/sys/kernel/hostname").ok()?;
+            let read_bytes = file.read(&mut hostname).ok()?;
 
-            if (1..=hostname.len()).contains(&read_bytes) && hostname[read_bytes - 1] == b'\n' {
+            // When reading /proc/sys/kernel/hostname file, the hostname should be
+            // terminated by a newline character, while libc gethostname() terminates
+            // the hostname with a null character. Hence, to match the behavior of
+            // gethostname() it is necessary to replace the newline with a null
+            // character. Note that since in POSIX there is no guarantee that hostname
+            // returned by procfs is always terminated by a newline character, we
+            // need to account for the possibility that the number of read bytes can be
+            // 0 and/or hostname is not terminated by a newline character.
+            if read_bytes > 0 && hostname[read_bytes - 1] == b'\n' {
                 hostname[read_bytes - 1] = 0
-            } else {
-                return None;
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -301,7 +301,7 @@ impl Config {
             // terminated by a newline character, while libc gethostname() terminates
             // the hostname with a null character. Hence, to match the behavior of
             // gethostname() it is necessary to replace the newline with a null
-            // character. Note that since in POSIX there is no guarantee that hostname
+            // character. Note that since there is no guarantee that hostname
             // returned by procfs is always terminated by a newline character, we
             // need to account for the possibility that the number of read bytes can be
             // 0 and/or hostname is not terminated by a newline character.

--- a/src/config.rs
+++ b/src/config.rs
@@ -302,8 +302,8 @@ impl Config {
                     Err(_) => return None,
                 };
 
-                if read_bytes < hostname.len() {
-                    hostname[read_bytes] = 0
+                if (1..hostname.len()).contains(&read_bytes) && hostname[read_bytes - 1] == b'\n' {
+                    hostname[read_bytes - 1] = 0
                 } else {
                     return None;
                 }


### PR DESCRIPTION
https://github.com/hickory-dns/resolv-conf/pull/44 has introduced a regression that breaks building statically linked applications that depend on `resolv-conf` as explained in https://github.com/hickory-dns/resolv-conf/issues/49.

This PR 
* uses `gethostname` from `libc` crate to solve the issue with static builds,
* bumps version to 0.7.4

Note that since now there is an optional dependency on `libc`, I put `get_system_domain` behind `system` feature to avoid pulling it when it's not needed.